### PR TITLE
Handling decoding errors

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Mix.Config
 
 import_config "#{Mix.env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Mix.Config
 
 config :logger, level: :info

--- a/lib/coap/block.ex
+++ b/lib/coap/block.ex
@@ -58,6 +58,10 @@ defmodule CoAP.Block do
   def decode(<<number::size(28), more::size(1), size_exponent::size(3)>>),
     do: decode(number, more, size_exponent)
 
+  def decode(number) do
+    decode(number, 0, 0)
+  end
+
   @spec decode(integer, 0 | 1, integer) :: t()
   def decode(number, more, size_exponent) do
     %__MODULE__{

--- a/lib/coap/message_options.ex
+++ b/lib/coap/message_options.ex
@@ -73,8 +73,13 @@ defmodule CoAP.MessageOptions do
             {new_tail1, delta_sum + key + 13}
 
           delta == 14 ->
-            <<key::size(16), new_tail1::binary>> = tail
-            {new_tail1, delta_sum + key + 269}
+            case tail do
+              <<key::size(16), new_tail1::binary>> ->
+                {new_tail1, delta_sum + key + 269}
+
+              _ ->
+                throw({:error, :invalid_option})
+            end
         end
 
       {tail2, option_length} =

--- a/lib/coap/message_options.ex
+++ b/lib/coap/message_options.ex
@@ -56,7 +56,9 @@ defmodule CoAP.MessageOptions do
           decode(rest, key, append_option(CoAP.MessageOption.decode(key, value), option_list))
 
         <<>> ->
-          decode(<<>>, key, append_option(CoAP.MessageOption.decode(key, <<>>), option_list))
+          option = CoAP.MessageOption.decode(key, <<>>)
+          option_list = append_option(option, option_list)
+          decode(<<>>, key, option_list)
       end
     end
 

--- a/test/coap/socket_server_test.exs
+++ b/test/coap/socket_server_test.exs
@@ -1,0 +1,79 @@
+defmodule CoAP.SocketServerTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureLog
+
+  alias CoAP.SocketServer
+  alias CoAP.Adapters.GenericServer
+
+  defmodule FakeEndpoint do
+  end
+
+  describe "CoAP.SocketServer decoding errors" do
+    test "non repeatable options" do
+      peer_ip = "127.0.0.1"
+      peer_port = 5830
+
+      {:ok, server} = SocketServer.start_link([{GenericServer, FakeEndpoint}, peer_port])
+
+      data =
+        <<100, 69, 0, 1, 252, 1, 46, 56, 68, 80, 231, 168, 249, 100, 69, 0, 1, 252, 1, 46, 56, 68,
+          80, 231, 168, 249>>
+
+      log =
+        capture_log(fn ->
+          ref = Process.monitor(server)
+          send(server, {:udp, :socket, peer_ip, peer_port, data})
+
+          response =
+            receive do
+              {:DOWN, ^ref, :process, ^server, _reason} ->
+                :ok
+            after
+              100 -> {:error, {:timeout, :await_response}}
+            end
+
+          assert response == :ok
+        end)
+
+      assert log =~ "CoAP socket failed to decode udp packets"
+      assert log =~ "is not repeatable"
+      assert log =~ "from ip: \"#{peer_ip}\""
+      assert log =~ "port: #{peer_port}"
+      assert log =~ "data: #{inspect(data, binaries: :as_binary)}"
+    end
+
+    test "CaseClauseError" do
+      peer_ip = "127.0.0.1"
+      peer_port = 5830
+
+      {:ok, server} = SocketServer.start_link([{GenericServer, FakeEndpoint}, peer_port])
+
+      data =
+        <<100, 69, 0, 1, 83, 61, 239, 152, 68, 244, 81, 253, 46, 100, 69, 0, 1, 83, 61, 239, 152,
+          68, 244, 81, 253, 46>>
+
+      log =
+        capture_log(fn ->
+          ref = Process.monitor(server)
+          send(server, {:udp, :socket, peer_ip, peer_port, data})
+
+          response =
+            receive do
+              {:DOWN, ^ref, :process, ^server, _reason} ->
+                :ok
+            after
+              100 -> {:error, {:timeout, :await_response}}
+            end
+
+          assert response == :ok
+        end)
+
+      assert log =~ "CoAP socket failed to decode udp packets"
+      assert log =~ "CaseClauseError"
+      assert log =~ "from ip: \"#{peer_ip}\""
+      assert log =~ "port: #{peer_port}"
+      assert log =~ "data: #{inspect(data, binaries: :as_binary)}"
+    end
+  end
+end


### PR DESCRIPTION
When the SocketServer attempts to decode messages there is the possibility of error caused by bad data.

This commit adapts the code so that any exceptions caused by decoding are captured, and a warning is logged, and the process is stopped without causing an error.

The types of errors seen were:

- bad return value: {:error, "" is not repeatable""}
- (CondClauseError) no cond clause evaluated to a truthy value (coap_ex 0.1.0) lib/coap/message_options.ex
- (CaseClauseError) no case clause matching <<...>> (coap_ex 0.1.0) lib/coap/message_options.ex:54   
- (FunctionClauseError) no function clause matching in CoAP.Block.decode/1 
- (MatchError) no match of right hand side value: """"

One could argue that these "errors" should be fixed by updating the MessageOptions module to gracefully handle such conditions, and that is definitely worth considering. By doing that, we would then be able to complete the decoding, which would allow extracting the message token which is required to identify the associated connection process.




## Bad Return

```
GenServer #PID<0.12197.249> terminating** (stop) bad return value: {:error, "" is not repeatable""}

Last message: {:udp, #Port<0.1357880>, {10, 148, 4, 179}, 1200, <<227, 3, 7, 2, 0, 0, 0, 157, 87, 43, 90, 195, 102, 208, 55, 202, 12, 234, 12, 241, 12, 217, 12, 85, 250, 113, 61, 120, 0, 140, 192, 91, 13, 39, 0, 13, 0, 169, 4, 0, 0, 131, 92, 195, 102, ...>>}
```

This error happens because when a non repeatable option is encountered by the `MessageOptions.Decoder`, it throws an exception which is not caught, resulting in the `SocketServer` process returning the error from the `handle_info/2` genserver callback. This causes the process to stop, because `{:error, "" is not repeatable""}` is not a valid `handle_info/2` response.

Fixing this issue would involve "catching" the exception, and ensure the SocketServer is able to return a valid response from the handle_info/2 callback.

## CondClauseError

```
GenServer #PID<0.3708.144> terminating** (CondClauseError) no cond clause evaluated to a truthy value 
(coap_ex 0.1.0) lib/coap/message_options.ex:73: CoAP.MessageOptions.Decoder.decode_extended/4 
(coap_ex 0.1.0) lib/coap/message_options.ex:51: CoAP.MessageOptions.Decoder.decode/3 
(coap_ex 0.1.0) lib/coap/message_options.ex:42: CoAP.MessageOptions.Decoder.options_and_payload/1 
(coap_ex 0.1.0) lib/coap/message.ex:241: CoAP.Message.decode/1 
(coap_ex 0.1.0) lib/coap/socket_server.ex:94: CoAP.SocketServer.handle_info/2 
(stdlib 3.17.2.1) gen_server.erl:695: :gen_server.try_dispatch/4 
(stdlib 3.17.2.1) gen_server.erl:771: :gen_server.handle_msg/6 
(stdlib 3.17.2.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3

Last message: {:udp, #Port<0.788077>, {10, 150, 51, 74}, 5683, <<100, 69, 0, 1, 239, 70, 20, 250, 68, 105, 29, 80, 244, 100, 69, 0, 1, 239, 70, 20, 250, 68, 105, 29, 80, 244>>}
```

This error happens because there is no clause which returns truthy - this cond could be updated to include a base case which throws an exception.
